### PR TITLE
#52 #58 Make Notifications Use Polymorphism

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,6 @@
         <activity android:name=".SupervisedGroupPageActivity" />
         <activity android:name=".SupervisedGroupListActivity" />
         <activity android:name=".MonitoringGroupPageActivity" />
-        android:theme="@style/AppTheme">
         <activity android:name=".NotificationActivity" />
         <activity android:name=".HomeActivity" />
         <activity android:name=".LoginActivity" />

--- a/app/src/main/java/com/example/bigowlapp/repository/NotificationRepository.java
+++ b/app/src/main/java/com/example/bigowlapp/repository/NotificationRepository.java
@@ -1,9 +1,6 @@
 package com.example.bigowlapp.repository;
 
-import android.util.Log;
-
 import androidx.annotation.VisibleForTesting;
-import androidx.lifecycle.MutableLiveData;
 
 import com.example.bigowlapp.model.Notification;
 import com.example.bigowlapp.model.SupervisionRequest;
@@ -30,26 +27,7 @@ public class NotificationRepository extends Repository<Notification> {
     }
 
     @Override
-    public MutableLiveData<List<Notification>> getAllDocumentsFromCollection(Class<? extends Notification> tClass) {
-        MutableLiveData<List<Notification>> listOfTData = new MutableLiveData<>();
-        this.collectionReference.get()
-                .addOnCompleteListener(task -> {
-                    if (task.isSuccessful()) {
-                        QuerySnapshot tDocs = task.getResult();
-                        if (tDocs != null && !tDocs.isEmpty()) {
-                            listOfTData.setValue(this.createNotificationListUsingType(task.getResult()));
-                        } else {
-                            listOfTData.setValue(null);
-                        }
-                    } else {
-                        Log.e(getClassName(), "Error getting documents: " +
-                                task.getException());
-                    }
-                });
-        return listOfTData;
-    }
-
-    List<Notification> createNotificationListUsingType(QuerySnapshot results) {
+    List<Notification> extractListOfDataToModel(QuerySnapshot results, Class<? extends Notification> tClass) {
         List<Notification> notificationsFromDb = new ArrayList<>();
         for (QueryDocumentSnapshot doc : results) {
             String type = doc.toObject(Notification.class).getType();

--- a/app/src/main/java/com/example/bigowlapp/repository/NotificationRepository.java
+++ b/app/src/main/java/com/example/bigowlapp/repository/NotificationRepository.java
@@ -1,11 +1,60 @@
 package com.example.bigowlapp.repository;
 
+import android.util.Log;
+
+import androidx.lifecycle.MutableLiveData;
+
 import com.example.bigowlapp.model.Notification;
+import com.example.bigowlapp.model.SupervisionRequest;
+import com.example.bigowlapp.utils.Constants;
+import com.google.firebase.firestore.QueryDocumentSnapshot;
+import com.google.firebase.firestore.QuerySnapshot;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class NotificationRepository extends Repository<Notification> {
 
     // TODO: Dependency Injection Implementation for Firestore
     public NotificationRepository() {
         super("notifications");
+    }
+
+    @Override
+    public MutableLiveData<List<Notification>> getAllDocumentsFromCollection(Class<? extends Notification> tClass) {
+        MutableLiveData<List<Notification>> listOfTData = new MutableLiveData<>();
+        this.collectionReference.get()
+                .addOnCompleteListener(task -> {
+                    if (task.isSuccessful()) {
+                        QuerySnapshot tDocs = task.getResult();
+                        if (tDocs != null && !tDocs.isEmpty()) {
+                            listOfTData.setValue(this.createNotificationListUsingType(task.getResult()));
+                        } else {
+                            listOfTData.setValue(null);
+                        }
+                    } else {
+                        Log.e(getClassName(), "Error getting documents: " +
+                                task.getException());
+                    }
+                });
+        return listOfTData;
+    }
+
+    private List<Notification> createNotificationListUsingType(QuerySnapshot results) {
+        List<Notification> notificationsFromDb = new ArrayList<>();
+        for (QueryDocumentSnapshot doc : results) {
+            String type = doc.toObject(Notification.class).getType();
+            Notification t = doc.toObject(this.getClassFromType(type));
+            notificationsFromDb.add(t);
+        }
+        return notificationsFromDb;
+    }
+
+    private Class<? extends Notification> getClassFromType(String type) {
+        if (type.equals(Constants.SUPERVISION_TYPE)) {
+            return SupervisionRequest.class;
+        } else {
+            return Notification.class;
+        }
     }
 }

--- a/app/src/main/java/com/example/bigowlapp/repository/NotificationRepository.java
+++ b/app/src/main/java/com/example/bigowlapp/repository/NotificationRepository.java
@@ -2,11 +2,14 @@ package com.example.bigowlapp.repository;
 
 import android.util.Log;
 
+import androidx.annotation.VisibleForTesting;
 import androidx.lifecycle.MutableLiveData;
 
 import com.example.bigowlapp.model.Notification;
 import com.example.bigowlapp.model.SupervisionRequest;
 import com.example.bigowlapp.utils.Constants;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.QueryDocumentSnapshot;
 import com.google.firebase.firestore.QuerySnapshot;
 
@@ -18,6 +21,12 @@ public class NotificationRepository extends Repository<Notification> {
     // TODO: Dependency Injection Implementation for Firestore
     public NotificationRepository() {
         super("notifications");
+    }
+
+    // TODO: Remove or Modify when dependency injection implemented
+    @VisibleForTesting
+    public NotificationRepository(FirebaseFirestore mFirebaseFirestore, CollectionReference collectionReference) {
+        super(mFirebaseFirestore, collectionReference);
     }
 
     @Override
@@ -40,7 +49,7 @@ public class NotificationRepository extends Repository<Notification> {
         return listOfTData;
     }
 
-    private List<Notification> createNotificationListUsingType(QuerySnapshot results) {
+    List<Notification> createNotificationListUsingType(QuerySnapshot results) {
         List<Notification> notificationsFromDb = new ArrayList<>();
         for (QueryDocumentSnapshot doc : results) {
             String type = doc.toObject(Notification.class).getType();
@@ -50,11 +59,16 @@ public class NotificationRepository extends Repository<Notification> {
         return notificationsFromDb;
     }
 
-    private Class<? extends Notification> getClassFromType(String type) {
+    Class<? extends Notification> getClassFromType(String type) {
+        if (type == null) {
+            return Notification.class;
+        }
+
         if (type.equals(Constants.SUPERVISION_TYPE)) {
             return SupervisionRequest.class;
         } else {
             return Notification.class;
         }
     }
+
 }

--- a/app/src/main/java/com/example/bigowlapp/repository/Repository.java
+++ b/app/src/main/java/com/example/bigowlapp/repository/Repository.java
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public abstract class Repository<T> {
 
     private FirebaseFirestore mFirebaseFirestore;
-    private CollectionReference collectionReference;
+    protected CollectionReference collectionReference;
 
     public Repository(String collectionName) {
         mFirebaseFirestore = Firestore.getDatabase();

--- a/app/src/main/java/com/example/bigowlapp/repository/Repository.java
+++ b/app/src/main/java/com/example/bigowlapp/repository/Repository.java
@@ -2,6 +2,7 @@ package com.example.bigowlapp.repository;
 
 import android.util.Log;
 
+import androidx.annotation.VisibleForTesting;
 import androidx.lifecycle.MutableLiveData;
 
 import com.example.bigowlapp.database.Firestore;
@@ -24,6 +25,13 @@ public abstract class Repository<T> {
     public Repository(String collectionName) {
         mFirebaseFirestore = Firestore.getDatabase();
         collectionReference = mFirebaseFirestore.collection(collectionName);
+    }
+
+    // TODO: Remove or Modify when dependency injection implemented
+    @VisibleForTesting
+    public Repository(FirebaseFirestore mFirebaseFirestore, CollectionReference collectionReference) {
+        this.mFirebaseFirestore = mFirebaseFirestore;
+        this.collectionReference = collectionReference;
     }
 
     //===========================================================================================

--- a/app/src/main/java/com/example/bigowlapp/repository/Repository.java
+++ b/app/src/main/java/com/example/bigowlapp/repository/Repository.java
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public abstract class Repository<T> {
 
-    private FirebaseFirestore mFirebaseFirestore;
+    private final FirebaseFirestore mFirebaseFirestore;
     protected CollectionReference collectionReference;
 
     public Repository(String collectionName) {
@@ -158,12 +158,7 @@ public abstract class Repository<T> {
                     if (task.isSuccessful()) {
                         QuerySnapshot tDocs = task.getResult();
                         if (tDocs != null && !tDocs.isEmpty()) {
-                            List<T> listOfT = new ArrayList<>();
-                            for (QueryDocumentSnapshot doc : task.getResult()) {
-                                T t = doc.toObject(tClass);
-                                listOfT.add(t);
-                            }
-                            listOfTData.setValue(listOfT);
+                            listOfTData.setValue(this.extractListOfDataToModel(task.getResult(), tClass));
                         } else {
                             listOfTData.setValue(null);
                         }
@@ -182,12 +177,7 @@ public abstract class Repository<T> {
                     if (task.isSuccessful()) {
                         QuerySnapshot tDocs = task.getResult();
                         if (tDocs != null && !tDocs.isEmpty()) {
-                            List<T> listOfT = new ArrayList<>();
-                            for (QueryDocumentSnapshot doc : task.getResult()) {
-                                T t = doc.toObject(tClass);
-                                listOfT.add(t);
-                            }
-                            listOfTData.setValue(listOfT);
+                            listOfTData.setValue(this.extractListOfDataToModel(task.getResult(), tClass));
                         } else {
                             listOfTData.setValue(null);
                         }
@@ -197,6 +187,15 @@ public abstract class Repository<T> {
                     }
                 });
         return listOfTData;
+    }
+
+    List<T> extractListOfDataToModel(QuerySnapshot results, Class<? extends T> tClass) {
+        List<T> listOfT = new ArrayList<>();
+        for (QueryDocumentSnapshot doc : results) {
+            T t = doc.toObject(tClass);
+            listOfT.add(t);
+        }
+        return listOfT;
     }
 
     String getClassName() {

--- a/app/src/test/java/com/example/bigowlapp/repository/NotificationRepositoryTest.java
+++ b/app/src/test/java/com/example/bigowlapp/repository/NotificationRepositoryTest.java
@@ -1,0 +1,33 @@
+package com.example.bigowlapp.repository;
+
+import com.example.bigowlapp.model.Notification;
+import com.example.bigowlapp.model.SupervisionRequest;
+import com.example.bigowlapp.utils.Constants;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class NotificationRepositoryTest {
+
+    private NotificationRepository notificationRepository;
+
+    @Before
+    public void setUp() {
+        notificationRepository = new NotificationRepository(null, null);
+    }
+
+    @Test
+    public void getClassFromType() {
+        String nullType = null;
+        assertEquals(Notification.class, notificationRepository.getClassFromType(nullType));
+        String emptyType = "";
+        assertEquals(Notification.class, notificationRepository.getClassFromType(emptyType));
+        String randomType = "someRandomString";
+        assertEquals(Notification.class, notificationRepository.getClassFromType(randomType));
+
+        String reservedSupervisionNotificationType = Constants.SUPERVISION_TYPE;
+        assertEquals(SupervisionRequest.class, notificationRepository.getClassFromType(reservedSupervisionNotificationType));
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.0.2'
         classpath 'com.google.gms:google-services:4.3.4'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
**Related Issues:**
#52, #58 

**Note:**
This is only going to be added to `#52-respond-to-supervision-notification`, not staging

**Description:**
When getting notifications from the database, they should now be set to the correct object type and not always be created as notification objects.