### PR TITLE
[#63, #64] Added dependencies for local unit and instrumental test

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'androidx.test:core:1.0.0'
     testImplementation 'org.mockito:mockito-core:1.10.19'
+    testImplementation 'org.hamcrest:hamcrest:2.2'
 
     // Declare instrumented unit tests
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     androidTestImplementation 'androidx.test:runner:1.1.0'
     androidTestImplementation 'androidx.test:rules:1.1.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
     androidTestImplementation 'org.hamcrest:hamcrest-library:1.3'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,6 @@ android {
         multiDexEnabled true
         versionCode 1
         versionName "1.0"
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
     }
@@ -23,6 +22,7 @@ android {
 
         unitTests {
             includeAndroidResources = true
+            unitTests.includeAndroidResources = true
         }
     }
 
@@ -42,8 +42,6 @@ android {
 }
 
 dependencies {
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.2'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
@@ -61,8 +59,19 @@ dependencies {
     implementation 'androidx.navigation:navigation-fragment:2.3.0'
     implementation 'androidx.navigation:navigation-ui:2.3.0'
     implementation 'de.hdodenhof:circleimageview:3.1.0'
-    // Declare testing dependencies
+
+    // Declare local unit testing dependencies
     testImplementation 'junit:junit:4.12'
+    testImplementation 'androidx.test:core:1.0.0'
+    testImplementation 'org.mockito:mockito-core:1.10.19'
+
+    // Declare instrumented unit tests
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test:runner:1.1.0'
+    androidTestImplementation 'androidx.test:rules:1.1.0'
+    androidTestImplementation 'org.hamcrest:hamcrest-library:1.3'
+    androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
+
 
     // TODO: remove below line after switch the db from Realtime Database to Cloud Firestore
     implementation 'com.google.firebase:firebase-database'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,6 @@ android {
 
         unitTests {
             includeAndroidResources = true
-            unitTests.includeAndroidResources = true
         }
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     androidTestImplementation 'androidx.test:runner:1.1.0'
     androidTestImplementation 'androidx.test:rules:1.1.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'org.hamcrest:hamcrest-library:1.3'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
 


### PR DESCRIPTION
Issues: #63, #64 

Added dependencies for local and instrumental unit tests.

For local unit test:
- Junit test for our basic testing library
- Robolectric for running android code without an emulator
- Mockito for mocking object/classes

For instrumental test:
- Espresso for running the UI test under an emulator
- Hamcrest for readability of the tests
- UI automator for building UI tests that involve interactions on system and user apps.