### PR TITLE
#183 Schedule not accesible when added using the Schedule Form

### DIFF
--- a/app/src/main/java/com/example/bigowlapp/repository/ScheduleRepository.java
+++ b/app/src/main/java/com/example/bigowlapp/repository/ScheduleRepository.java
@@ -27,7 +27,7 @@ public class ScheduleRepository extends Repository<Schedule> {
     public MutableLiveData<List<Schedule>> getListSchedulesFromGroupForUser(String groupID, String userID) {
         MutableLiveData<List<Schedule>> listOfTData = new MutableLiveData<>();
         collectionReference.whereEqualTo("groupUId", groupID)
-                .whereArrayContains("membersList", userID)
+                .whereArrayContains("memberList", userID)
                 .orderBy("startTime", Query.Direction.ASCENDING)
                 .get()
                 .addOnCompleteListener(task -> {

--- a/app/src/main/java/com/example/bigowlapp/viewModel/ScheduleViewRespondViewModel.java
+++ b/app/src/main/java/com/example/bigowlapp/viewModel/ScheduleViewRespondViewModel.java
@@ -1,5 +1,6 @@
 package com.example.bigowlapp.viewModel;
 
+import androidx.annotation.VisibleForTesting;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
@@ -84,5 +85,17 @@ public class ScheduleViewRespondViewModel extends ViewModel {
 
         long userLastResponseTime = responseTimestamp.toDate().getTime();
         return now().toDate().getTime() >= (userLastResponseTime + ONE_MINUTE);
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    public ScheduleViewRespondViewModel(AuthRepository authRepository, NotificationRepository notificationRepository, ScheduleRepository scheduleRepository) {
+        this.authRepository = authRepository;
+        this.notificationRepository = notificationRepository;
+        this.scheduleRepository = scheduleRepository;
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    public void setScheduleData(MutableLiveData<Schedule> scheduleData) {
+        this.scheduleData = scheduleData;
     }
 }

--- a/app/src/main/java/com/example/bigowlapp/viewModel/ScheduleViewRespondViewModel.java
+++ b/app/src/main/java/com/example/bigowlapp/viewModel/ScheduleViewRespondViewModel.java
@@ -11,6 +11,7 @@ import com.example.bigowlapp.model.UserScheduleResponse;
 import com.example.bigowlapp.repository.AuthRepository;
 import com.example.bigowlapp.repository.NotificationRepository;
 import com.example.bigowlapp.repository.ScheduleRepository;
+import com.google.firebase.Timestamp;
 
 import java.util.Objects;
 
@@ -74,7 +75,14 @@ public class ScheduleViewRespondViewModel extends ViewModel {
     }
 
     public boolean isOneMinuteAfterLastResponse() {
-        long userLastResponseTime = getUserScheduleResponse().getResponseTime().toDate().getTime();
+        Timestamp responseTimestamp = getUserScheduleResponse().getResponseTime();
+
+        // If there was no response yet, than we should allow response to go through
+        if (responseTimestamp == null) {
+            return true;
+        }
+
+        long userLastResponseTime = responseTimestamp.toDate().getTime();
         return now().toDate().getTime() >= (userLastResponseTime + ONE_MINUTE);
     }
 }

--- a/app/src/main/java/com/example/bigowlapp/viewModel/ScheduleViewRespondViewModel.java
+++ b/app/src/main/java/com/example/bigowlapp/viewModel/ScheduleViewRespondViewModel.java
@@ -78,7 +78,7 @@ public class ScheduleViewRespondViewModel extends ViewModel {
     public boolean isOneMinuteAfterLastResponse() {
         Timestamp responseTimestamp = getUserScheduleResponse().getResponseTime();
 
-        // If there was no response yet, than we should allow response to go through
+        // If there was no response yet, then we should allow response to go through
         if (responseTimestamp == null) {
             return true;
         }

--- a/app/src/test/java/com/example/bigowlapp/viewModel/ScheduleViewRespondViewModelTest.java
+++ b/app/src/test/java/com/example/bigowlapp/viewModel/ScheduleViewRespondViewModelTest.java
@@ -1,0 +1,99 @@
+package com.example.bigowlapp.viewModel;
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.lifecycle.MutableLiveData;
+
+import com.example.bigowlapp.model.Response;
+import com.example.bigowlapp.model.Schedule;
+import com.example.bigowlapp.model.User;
+import com.example.bigowlapp.model.UserScheduleResponse;
+import com.example.bigowlapp.repository.AuthRepository;
+import com.google.firebase.Timestamp;
+import com.google.firebase.auth.FirebaseUser;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ScheduleViewRespondViewModelTest {
+
+    public static long ONE_SECOND = 1000;
+
+    private ScheduleViewRespondViewModel scheduleViewRespondViewModel;
+    private MutableLiveData<Schedule> testScheduleData;
+    private User testUser;
+
+    @Rule
+    public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
+
+    @Mock
+    private AuthRepository mockAuthRepository;
+    @Mock
+    private FirebaseUser mockTestFirebaseUser;
+
+    @Before
+    public void setUp() {
+        // setup fake data
+        testUser = new User("abc123", "first", "last", "+911", "test@mail.com", "url");
+        testScheduleData = new MutableLiveData<>(createFakeSchedule());
+
+        // setup mock responses
+        when(mockAuthRepository.getCurrentUser()).thenReturn(mockTestFirebaseUser);
+        when(mockTestFirebaseUser.getUid()).thenReturn("abc123");
+
+        // setup viewModel to be tested
+        scheduleViewRespondViewModel = new ScheduleViewRespondViewModel(mockAuthRepository, null, null);
+        scheduleViewRespondViewModel.setScheduleData(testScheduleData);
+    }
+
+    @Test
+    public void isOneMinuteAfterLastResponse() {
+        Map<String, UserScheduleResponse> userScheduleResponseMap = testScheduleData.getValue().getUserScheduleResponseMap();
+
+        // case where user did not respond yet
+        UserScheduleResponse neutralResponse = new UserScheduleResponse(Response.NEUTRAL, null);
+        userScheduleResponseMap.put(testUser.getUId(), neutralResponse);
+        assertTrue(scheduleViewRespondViewModel.isOneMinuteAfterLastResponse());
+
+        // case where the response is greater than a minute before
+        Date lateTime = new Date();
+        lateTime.setTime(lateTime.getTime() - 300 * ONE_SECOND);
+        UserScheduleResponse oldResponse = new UserScheduleResponse(Response.ACCEPT, new Timestamp(lateTime));
+        userScheduleResponseMap.put(testUser.getUId(), oldResponse);
+        assertTrue(scheduleViewRespondViewModel.isOneMinuteAfterLastResponse());
+
+        // case where the response is less than a minute before
+        Date earlyTime = new Date();
+        earlyTime.setTime(earlyTime.getTime() - 30 * ONE_SECOND);
+        UserScheduleResponse quickResponse = new UserScheduleResponse(Response.REJECT, new Timestamp(earlyTime));
+        userScheduleResponseMap.put(testUser.getUId(), quickResponse);
+        assertFalse(scheduleViewRespondViewModel.isOneMinuteAfterLastResponse());
+
+        // case where the response is slightly more than a minute
+        Date closeTime = new Date();
+        closeTime.setTime(closeTime.getTime() - 61 * ONE_SECOND);
+        UserScheduleResponse oneMinuteResponse = new UserScheduleResponse(Response.ACCEPT, new Timestamp(closeTime));
+        userScheduleResponseMap.put(testUser.getUId(), oneMinuteResponse);
+        assertTrue(scheduleViewRespondViewModel.isOneMinuteAfterLastResponse());
+    }
+
+    private Schedule createFakeSchedule() {
+        Map<String, UserScheduleResponse> userScheduleResponseMap = new HashMap<>();
+        userScheduleResponseMap.put(testUser.getUId(), new UserScheduleResponse(Response.NEUTRAL, null));
+        Schedule fakeSchedule = Schedule.getPrototypeSchedule();
+        fakeSchedule.setUserScheduleResponseMap(userScheduleResponseMap);
+        return fakeSchedule;
+    }
+}


### PR DESCRIPTION
<!--
NOTE: Please set, 
- reviewers for the PR
- assign yourself in "Assignees"
- "pull request" label for "Labels"
- set the correct "Milestone",
- set the "Linked Issues" to the issue this PR would close, if any

in the menu on the right
-->

### Related Issues
Closes #183 

### Description
I fixed the bug in which schedules were not showing up in the list that allows us to accept or reject them

### How to check PR
1. Login as a user with group members
2. Set a schedule for one or more of the group members using set schedule
3. Logout and now login as a user you just added a schedule for
4. Click on "Supervised Group"
5. Click on the group where you added the schedule with the first user
6. Click on Schedule

The schedule should be in the schedule list.
