### PR TITLE
#138 monitoring group bug

### DIFF
--- a/app/src/androidTest/java/com/example/bigowlapp/activity/EditProfileViewTest.java
+++ b/app/src/androidTest/java/com/example/bigowlapp/activity/EditProfileViewTest.java
@@ -1,6 +1,10 @@
 package com.example.bigowlapp.activity;
 
-import android.os.SystemClock;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.MutableLiveData;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
 
 import com.example.bigowlapp.R;
 import com.example.bigowlapp.model.User;
@@ -12,12 +16,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-
-import androidx.lifecycle.Lifecycle;
-import androidx.lifecycle.MutableLiveData;
-import androidx.test.espresso.Espresso;
-import androidx.test.ext.junit.rules.ActivityScenarioRule;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
@@ -34,6 +32,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(AndroidJUnit4.class)
+@LargeTest
 public class EditProfileViewTest {
 
     @Rule
@@ -54,6 +53,7 @@ public class EditProfileViewTest {
                 "BeforeEditLastName",
                 "+1234567890",
                 "tester@mail.com",
+                null,
                 null);
         MutableLiveData<User> testUserData = new MutableLiveData<>();
 

--- a/app/src/androidTest/java/com/example/bigowlapp/activity/HomePageActivityTest.java
+++ b/app/src/androidTest/java/com/example/bigowlapp/activity/HomePageActivityTest.java
@@ -2,6 +2,11 @@ package com.example.bigowlapp.activity;
 
 import android.os.SystemClock;
 
+import androidx.lifecycle.Lifecycle;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
 import com.example.bigowlapp.model.LiveDataWithStatus;
 import com.example.bigowlapp.model.User;
 import com.example.bigowlapp.viewModel.HomePageViewModel;
@@ -13,10 +18,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import androidx.lifecycle.Lifecycle;
-import androidx.test.ext.junit.rules.ActivityScenarioRule;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
-
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
@@ -25,6 +26,7 @@ import static org.mockito.Mockito.when;
 
 
 @RunWith(AndroidJUnit4.class)
+@LargeTest
 public class HomePageActivityTest {
 
     @Rule
@@ -40,7 +42,7 @@ public class HomePageActivityTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
 
-        testUser = new User("abc123", "test user", "abc", "+123", "test@mail.com", null);
+        testUser = new User("abc123", "test user", "abc", "+123", "test@mail.com", null, null);
         testUserData = new LiveDataWithStatus<>();
 
         when(homePageViewModel.isCurrentUserSet()).thenReturn(true);

--- a/app/src/androidTest/java/com/example/bigowlapp/activity/InvitationConfirmationActivityTest.java
+++ b/app/src/androidTest/java/com/example/bigowlapp/activity/InvitationConfirmationActivityTest.java
@@ -4,6 +4,8 @@ import android.app.Activity;
 import android.app.Instrumentation;
 
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
 
 import com.example.bigowlapp.R;
 
@@ -11,6 +13,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
@@ -18,6 +21,8 @@ import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 import static org.junit.Assert.assertNotNull;
 
+@RunWith(AndroidJUnit4.class)
+@LargeTest
 public class InvitationConfirmationActivityTest {
 
     @Rule

--- a/app/src/androidTest/java/com/example/bigowlapp/activity/MonitoringGroupPageActivityTest.java
+++ b/app/src/androidTest/java/com/example/bigowlapp/activity/MonitoringGroupPageActivityTest.java
@@ -4,6 +4,12 @@ import android.os.SystemClock;
 import android.view.View;
 import android.widget.ListView;
 
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.MutableLiveData;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
 import com.example.bigowlapp.R;
 import com.example.bigowlapp.model.Group;
 import com.example.bigowlapp.model.User;
@@ -21,12 +27,6 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import androidx.lifecycle.Lifecycle;
-import androidx.lifecycle.MutableLiveData;
-import androidx.test.ext.junit.rules.ActivityScenarioRule;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.filters.LargeTest;
 
 import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
@@ -72,6 +72,7 @@ public class MonitoringGroupPageActivityTest {
                     "#".concat(String.valueOf(i)),
                     null,
                     null,
+                    null,
                     null);
             testUserList.add(testUser);
             supervisedUsersIDs.add(String.valueOf(i));
@@ -98,7 +99,7 @@ public class MonitoringGroupPageActivityTest {
         testGroupData.postValue(testMonitoringGroup);
         testUserListData.postValue(testUserList);
 
-        SystemClock.sleep(3000);
+        SystemClock.sleep(500);
 
         assertEquals(testMonitoringGroup, currentActivity.getmGroupPageViewModel().getGroup().getValue());
         assertEquals(testUserList,
@@ -106,8 +107,6 @@ public class MonitoringGroupPageActivityTest {
                         .getmGroupPageViewModel()
                         .getUsersFromGroup(currentActivity.getmGroupPageViewModel().getGroup().getValue())
                         .getValue());
-
-        SystemClock.sleep(3000);
 
         int randomIndex = (int) (Math.random() * testUserList.size());
         onData(anything())
@@ -118,16 +117,10 @@ public class MonitoringGroupPageActivityTest {
 
         int testUserListAfterUserRemovedSize = testUserList.size() - 1;
 
-        SystemClock.sleep(3000);
-
         onView(allOf(withText("Remove"), isDisplayed()))
                 .perform(click());
 
-        SystemClock.sleep(3000);
-
         assertEquals(testUserListAfterUserRemovedSize, testUserList.size());
-
-        SystemClock.sleep(3000);
     }
 
     public static Matcher<View> withListSize(final int size) {

--- a/app/src/androidTest/java/com/example/bigowlapp/activity/ScheduleViewRespondActivityTest.java
+++ b/app/src/androidTest/java/com/example/bigowlapp/activity/ScheduleViewRespondActivityTest.java
@@ -74,6 +74,7 @@ public class ScheduleViewRespondActivityTest {
                 "001",
                 "+1234567890",
                 "testSupervisor@mail.com",
+                null,
                 null);
         User testCurrentUser = new User(
                 "testCurrentUser001",
@@ -81,6 +82,7 @@ public class ScheduleViewRespondActivityTest {
                 "currentUser",
                 "+1111111111",
                 "testCurrentUser@mail.com",
+                null,
                 null);
 
         Map<String, UserScheduleResponse> testScheduleMembersMap = new HashMap<>();

--- a/app/src/androidTest/java/com/example/bigowlapp/activity/ScheduleViewRespondActivityTest.java
+++ b/app/src/androidTest/java/com/example/bigowlapp/activity/ScheduleViewRespondActivityTest.java
@@ -94,14 +94,14 @@ public class ScheduleViewRespondActivityTest {
         testSchedule.setUid("schedule001");
         testSchedule.setTitle("testSchedule001");
         testSchedule.setEvent("testEvent001");
-        testSchedule.setGroupUId("testGroup001");
-        testSchedule.setGroupSupervisorUId(testSupervisor.getUid());
+        testSchedule.setGroupUid("testGroup001");
+        testSchedule.setGroupSupervisorUid(testSupervisor.getUid());
         testSchedule.setStartTime(Timestamp.now());
         testSchedule.setEndTime(new Timestamp(Timestamp.now().getSeconds() + 600000, 0));
         testSchedule.setLocation(new GeoPoint(0, 0));
         testSchedule.setUserScheduleResponseMap(testScheduleMembersMap);
         Intent testIntent = new Intent(ApplicationProvider.getApplicationContext(), ScheduleViewRespondActivity.class);
-        testIntent.putExtra("scheduleUId", testSchedule.getUid());
+        testIntent.putExtra("scheduleUid", testSchedule.getUid());
         testIntent.putExtra("groupName", "test group");
         testIntent.putExtra("supervisorName", testSupervisor.getFullName());
 

--- a/app/src/androidTest/java/com/example/bigowlapp/activity/SetScheduleActivityTest.java
+++ b/app/src/androidTest/java/com/example/bigowlapp/activity/SetScheduleActivityTest.java
@@ -3,6 +3,7 @@ package com.example.bigowlapp.activity;
 import androidx.fragment.app.Fragment;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
 
 import com.example.bigowlapp.fragments.ScheduleFormFragment;
 
@@ -16,6 +17,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(AndroidJUnit4.class)
+@LargeTest
 public class SetScheduleActivityTest {
 
     @Rule

--- a/app/src/androidTest/java/com/example/bigowlapp/activity/SupervisedGroupListActivityTest.java
+++ b/app/src/androidTest/java/com/example/bigowlapp/activity/SupervisedGroupListActivityTest.java
@@ -127,7 +127,7 @@ public class SupervisedGroupListActivityTest {
             onView(allOf(withId(R.id.text_view_group_name), withText(testUserSupervisedGroupList.get(i).getName())))
                     .check(matches(isDisplayed()));
             // check if the supervisors full names are matched and displayed
-            String supervisorFullName = supervisedGroupListViewModel.getSupervisor(testUserSupervisedGroupList.get(i).getMonitoringUserId()).getValue().getFullName();
+            String supervisorFullName = supervisedGroupListViewModel.getSupervisor(testUserSupervisedGroupList.get(i).getSupervisorId()).getValue().getFullName();
             onView(allOf(withId(R.id.text_view_group_supervisor), withText(supervisorFullName))).check(matches(isDisplayed()));
         }
     }

--- a/app/src/androidTest/java/com/example/bigowlapp/activity/SupervisedGroupListActivityTest.java
+++ b/app/src/androidTest/java/com/example/bigowlapp/activity/SupervisedGroupListActivityTest.java
@@ -4,6 +4,7 @@ import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.MutableLiveData;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
 
 import com.example.bigowlapp.R;
 import com.example.bigowlapp.model.Group;
@@ -38,6 +39,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 @RunWith(AndroidJUnit4.class)
+@LargeTest
 public class SupervisedGroupListActivityTest {
 
     @Rule
@@ -60,7 +62,7 @@ public class SupervisedGroupListActivityTest {
     public void setUp() throws Exception {
         initMocks(this);
 
-        User testUser = new User("abc123", "first", "last", "+911", "test@mail.com", null);
+        User testUser = new User("abc123", "first", "last", "+911", "test@mail.com", null, null);
         MutableLiveData<User> testUserData = new MutableLiveData<>(testUser);
         testUserData.postValue(testUser);
 
@@ -72,6 +74,7 @@ public class SupervisedGroupListActivityTest {
                     "group00".concat(String.valueOf(i)).concat("lName"),
                     "+12300".concat(String.valueOf(i)),
                     "group00".concat(String.valueOf(i)).concat("@mail.com"),
+                    null,
                     null
             );
             LiveDataWithStatus<User> groupSupervisorData = new LiveDataWithStatus<>(groupSupervisor);

--- a/app/src/androidTest/java/com/example/bigowlapp/activity/WelcomePageActivityTest.java
+++ b/app/src/androidTest/java/com/example/bigowlapp/activity/WelcomePageActivityTest.java
@@ -9,6 +9,7 @@ import androidx.test.espresso.ViewAction;
 import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
 
 import com.example.bigowlapp.R;
 
@@ -23,6 +24,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.isRoot;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 
 @RunWith(AndroidJUnit4.class)
+@LargeTest
 public class WelcomePageActivityTest {
 
     @Rule

--- a/app/src/androidTest/java/com/example/bigowlapp/fragments/ScheduleFormFragmentTest.java
+++ b/app/src/androidTest/java/com/example/bigowlapp/fragments/ScheduleFormFragmentTest.java
@@ -165,7 +165,7 @@ public class ScheduleFormFragmentTest {
         when(mockSetScheduleViewModel.getSelectedGroup()).thenReturn(fakeListOfGroup.get(0));
         onView(withText("group_name")).perform(click());
         groupData.postValue(fakeListOfGroup.get(0));
-        fakeSchedule.setGroupUId(fakeSelectedGroup.getUid());
+        fakeSchedule.setGroupUid(fakeSelectedGroup.getUid());
         verify(mockSetScheduleViewModel).updateScheduleGroup(fakeListOfGroup.get(0));
         listOfUsersData.postValue(fakeListOfUsers);
 

--- a/app/src/androidTest/java/com/example/bigowlapp/fragments/ScheduleFormFragmentTest.java
+++ b/app/src/androidTest/java/com/example/bigowlapp/fragments/ScheduleFormFragmentTest.java
@@ -10,6 +10,7 @@ import androidx.lifecycle.MutableLiveData;
 import androidx.test.espresso.ViewInteraction;
 import androidx.test.espresso.contrib.PickerActions;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
 
 import com.example.bigowlapp.R;
 import com.example.bigowlapp.model.Group;
@@ -51,6 +52,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 @RunWith(AndroidJUnit4.class)
+@LargeTest
 public class ScheduleFormFragmentTest {
 
     private FragmentScenario<ScheduleFormFragment> fragmentScenario;

--- a/app/src/main/java/com/example/bigowlapp/activity/ListOfScheduleActivity.java
+++ b/app/src/main/java/com/example/bigowlapp/activity/ListOfScheduleActivity.java
@@ -58,7 +58,7 @@ public class ListOfScheduleActivity extends BigOwlActivity {
 
                     scheduleListView.setOnItemClickListener((arg0, v, position, arg3) -> {
                         Intent intent = new Intent(getBaseContext(), ScheduleViewRespondActivity.class);
-                        intent.putExtra("scheduleUId", schedules.get(position).getUid());
+                        intent.putExtra("scheduleUid", schedules.get(position).getUid());
                         intent.putExtra("groupID", groupID);
                         intent.putExtra("groupName", groupName);
                         intent.putExtra("supervisorName", supervisorName);

--- a/app/src/main/java/com/example/bigowlapp/activity/MonitoringGroupPageActivity.java
+++ b/app/src/main/java/com/example/bigowlapp/activity/MonitoringGroupPageActivity.java
@@ -67,7 +67,7 @@ public class MonitoringGroupPageActivity extends BigOwlActivity {
 
         mGroupPageViewModel.getGroup().observe(this, group -> {
             // TODO: better error or allow view page when accessing group with no users
-            if (group == null || group.getSupervisedUserId() == null || group.getSupervisedUserId().isEmpty()) {
+            if (group == null || group.getMemberIdList() == null || group.getMemberIdList().isEmpty()) {
                 this.noGroupAlert().show();
                 return;
             }

--- a/app/src/main/java/com/example/bigowlapp/activity/ScheduleViewRespondActivity.java
+++ b/app/src/main/java/com/example/bigowlapp/activity/ScheduleViewRespondActivity.java
@@ -17,14 +17,14 @@ import androidx.lifecycle.ViewModelProvider;
 
 public class ScheduleViewRespondActivity extends BigOwlActivity {
 
-    private String scheduleUId, groupName, supervisorName;
+    private String scheduleUid, groupName, supervisorName;
     private ScheduleViewRespondViewModel scheduleViewRespondViewModel;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         Intent intent = getIntent();
-        scheduleUId = intent.getStringExtra("scheduleUId");
+        scheduleUid = intent.getStringExtra("scheduleUid");
         groupName = intent.getStringExtra("groupName");
         supervisorName = intent.getStringExtra("supervisorName");
     }
@@ -45,7 +45,7 @@ public class ScheduleViewRespondActivity extends BigOwlActivity {
             return;
         }
 
-        scheduleViewRespondViewModel.getCurrentScheduleData(scheduleUId).observe(this, schedule -> {
+        scheduleViewRespondViewModel.getCurrentScheduleData(scheduleUid).observe(this, schedule -> {
             if (!scheduleViewRespondViewModel.isCurrentUserInSchedule()) {
                 return;
             }
@@ -81,7 +81,7 @@ public class ScheduleViewRespondActivity extends BigOwlActivity {
 
     private void userClickRespondButton(Response response) {
         if (scheduleViewRespondViewModel.isOneMinuteAfterLastResponse()) {
-            scheduleViewRespondViewModel.respondSchedule(scheduleUId, response);
+            scheduleViewRespondViewModel.respondSchedule(scheduleUid, response);
         } else
             Toast.makeText(this,
                     "User can only respond to a schedule 1 minute after last response",

--- a/app/src/main/java/com/example/bigowlapp/activity/SendingRequestToSuperviseActivity.java
+++ b/app/src/main/java/com/example/bigowlapp/activity/SendingRequestToSuperviseActivity.java
@@ -17,6 +17,7 @@ import com.google.firebase.Timestamp;
 
 import java.util.List;
 
+// TODO: Should be using a viewmodel
 public class SendingRequestToSuperviseActivity extends AppCompatActivity {
     String otherUserID;
     String currentUserID;

--- a/app/src/main/java/com/example/bigowlapp/activity/SendingRequestToSuperviseActivity.java
+++ b/app/src/main/java/com/example/bigowlapp/activity/SendingRequestToSuperviseActivity.java
@@ -80,7 +80,6 @@ public class SendingRequestToSuperviseActivity extends AppCompatActivity {
         supervisionRequest.setSenderUId(currentUserID);
         supervisionRequest.setResponse(SupervisionRequest.Response.NEUTRAL);
         supervisionRequest.setGroupUId(""); // TODO think about creating and setting group IDs
-        supervisionRequest.setTimeSent(Timestamp.now());
         supervisionRequest.setTime(Timestamp.now());
 
         if (!aRequestAlready) {

--- a/app/src/main/java/com/example/bigowlapp/activity/SendingRequestToSuperviseActivity.java
+++ b/app/src/main/java/com/example/bigowlapp/activity/SendingRequestToSuperviseActivity.java
@@ -77,10 +77,10 @@ public class SendingRequestToSuperviseActivity extends AppCompatActivity {
 
     private void doRequest() {
         SupervisionRequest supervisionRequest = new SupervisionRequest();
-        supervisionRequest.setReceiverUId(otherUserID);
-        supervisionRequest.setSenderUId(currentUserID);
+        supervisionRequest.setReceiverUid(otherUserID);
+        supervisionRequest.setSenderUid(currentUserID);
         supervisionRequest.setResponse(SupervisionRequest.Response.NEUTRAL);
-        supervisionRequest.setGroupUId(""); // TODO think about creating and setting group IDs
+        supervisionRequest.setGroupUid(""); // TODO think about creating and setting group IDs
         supervisionRequest.setTime(Timestamp.now());
 
         if (!aRequestAlready) {
@@ -101,14 +101,14 @@ public class SendingRequestToSuperviseActivity extends AppCompatActivity {
         // in repository until one is found
         supRequestBtn.setText(supBtnSend); // Default setText
         resultNoteTv.setText(noRequest);
-        LiveData<List<SupervisionRequest>> senderRequestsData = notificationRepository.getListOfSupervisionRequestByAttribute("senderUId", currentUserID, SupervisionRequest.class);
+        LiveData<List<SupervisionRequest>> senderRequestsData = notificationRepository.getListOfSupervisionRequestByAttribute("senderUid", currentUserID, SupervisionRequest.class);
         senderRequestsData.observe(this, senderRequests -> {
             if (senderRequests == null)
                 return;
             for (SupervisionRequest senderRequest : senderRequests) {
                 if (aRequestAlready) {
                     break;
-                } else if (senderRequest.getReceiverUId().equals(otherUser.getUid())) {
+                } else if (senderRequest.getReceiverUid().equals(otherUser.getUid())) {
 
                     if (senderRequest.getResponse().equals(SupervisionRequest.Response.ACCEPT)) {
                         supRequestBtn.setText(supBtnAlready);

--- a/app/src/main/java/com/example/bigowlapp/activity/SupervisedGroupListActivity.java
+++ b/app/src/main/java/com/example/bigowlapp/activity/SupervisedGroupListActivity.java
@@ -86,7 +86,7 @@ public class SupervisedGroupListActivity extends BigOwlActivity {
 
             // TODO: find a better way to do below without looping query in viewModel
             supervisedGroupListViewModel.getSupervisor(
-                    group.getMonitoringUserId()).observe((LifecycleOwner) parent.getContext(),
+                    group.getSupervisorId()).observe((LifecycleOwner) parent.getContext(),
                     supervisor -> {
                         groupSupervisor.setText(supervisor.getFullName());
                         supervisorNameList.add(supervisor.getFullName());

--- a/app/src/main/java/com/example/bigowlapp/fragments/ScheduleFormFragment.java
+++ b/app/src/main/java/com/example/bigowlapp/fragments/ScheduleFormFragment.java
@@ -263,7 +263,7 @@ public class ScheduleFormFragment extends Fragment
                 hasError = true;
             }
 
-            if (scheduleToAdd.getGroupUId() == null) {
+            if (scheduleToAdd.getGroupUid() == null) {
                 groupButton.setError("Please select a group");
                 hasError = true;
             }

--- a/app/src/main/java/com/example/bigowlapp/model/Group.java
+++ b/app/src/main/java/com/example/bigowlapp/model/Group.java
@@ -11,12 +11,12 @@ import java.util.List;
 public class Group extends Model {
 
     private String name;
-    private String monitoringUserId;
-    private List<String> supervisedUserId;
+    private String supervisorId;
+    private List<String> memberIdList;
 
     public Group() {
         super();
-        supervisedUserId = new ArrayList<>();
+        memberIdList = new ArrayList<>();
     }
 
     public Group(String uid, String name) {
@@ -24,11 +24,11 @@ public class Group extends Model {
         this.name = name;
     }
 
-    public Group(String uid, String name, String monitoringUserId, List<String> supervisedUserId) {
+    public Group(String uid, String name, String supervisorId, List<String> memberIdList) {
         super(uid);
         this.name = name;
-        this.monitoringUserId = monitoringUserId;
-        this.supervisedUserId = supervisedUserId;
+        this.supervisorId = supervisorId;
+        this.memberIdList = memberIdList;
     }
 
     public String getName() {
@@ -39,20 +39,20 @@ public class Group extends Model {
         this.name = name;
     }
 
-    public String getMonitoringUserId() {
-        return monitoringUserId;
+    public String getSupervisorId() {
+        return supervisorId;
     }
 
-    public void setMonitoringUserId(String monitoringUserId) {
-        this.monitoringUserId = monitoringUserId;
+    public void setSupervisorId(String supervisorId) {
+        this.supervisorId = supervisorId;
     }
 
-    public List<String> getSupervisedUserId() {
-        return (supervisedUserId == null) ? new ArrayList<>() : supervisedUserId;
+    public List<String> getMemberIdList() {
+        return (memberIdList == null) ? new ArrayList<>() : memberIdList;
     }
 
-    public void setSupervisedUserId(List<String> supervisedUserId) {
-        this.supervisedUserId = supervisedUserId;
+    public void setMemberIdList(List<String> memberIdList) {
+        this.memberIdList = memberIdList;
     }
 
 }

--- a/app/src/main/java/com/example/bigowlapp/model/Group.java
+++ b/app/src/main/java/com/example/bigowlapp/model/Group.java
@@ -24,8 +24,8 @@ public class Group extends Model {
         this.name = name;
     }
 
-    public Group(String uId, String name, String monitoringUserId, List<String> supervisedUserId) {
-        super(uId);
+    public Group(String uid, String name, String monitoringUserId, List<String> supervisedUserId) {
+        super(uid);
         this.name = name;
         this.monitoringUserId = monitoringUserId;
         this.supervisedUserId = supervisedUserId;

--- a/app/src/main/java/com/example/bigowlapp/model/Notification.java
+++ b/app/src/main/java/com/example/bigowlapp/model/Notification.java
@@ -18,13 +18,13 @@ public class Notification extends Model {
         this.type = type;
     }
 
-    public Notification(String uId, String type) {
-        super(uId);
+    public Notification(String uid, String type) {
+        super(uid);
         this.type = type;
     }
 
-    public Notification(String uId, String type, Timestamp time) {
-        super(uId);
+    public Notification(String uid, String type, Timestamp time) {
+        super(uid);
         this.type = type;
         this.time = time;
     }

--- a/app/src/main/java/com/example/bigowlapp/model/Schedule.java
+++ b/app/src/main/java/com/example/bigowlapp/model/Schedule.java
@@ -15,8 +15,8 @@ public class Schedule extends Model {
 
     private String title;
     private String event;
-    private String groupUId;
-    private String groupSupervisorUId;
+    private String groupUid;
+    private String groupSupervisorUid;
     private List<String> memberList;
     private Timestamp startTime;
     private Timestamp endTime;
@@ -57,20 +57,20 @@ public class Schedule extends Model {
         this.event = event;
     }
 
-    public String getGroupUId() {
-        return groupUId;
+    public String getGroupUid() {
+        return groupUid;
     }
 
-    public void setGroupUId(String groupUId) {
-        this.groupUId = groupUId;
+    public void setGroupUid(String groupUid) {
+        this.groupUid = groupUid;
     }
 
-    public String getGroupSupervisorUId() {
-        return groupSupervisorUId;
+    public String getGroupSupervisorUid() {
+        return groupSupervisorUid;
     }
 
-    public void setGroupSupervisorUId(String groupSupervisorUId) {
-        this.groupSupervisorUId = groupSupervisorUId;
+    public void setGroupSupervisorUid(String groupSupervisorUid) {
+        this.groupSupervisorUid = groupSupervisorUid;
     }
 
     public List<String> getMemberList() {

--- a/app/src/main/java/com/example/bigowlapp/model/Schedule.java
+++ b/app/src/main/java/com/example/bigowlapp/model/Schedule.java
@@ -105,14 +105,10 @@ public class Schedule extends Model {
         this.location = location;
     }
 
-    // TODO: Temp fix since db still has old field name
-    @PropertyName("members")
     public Map<String, UserScheduleResponse> getUserScheduleResponseMap() {
         return userScheduleResponseMap;
     }
 
-    // TODO: Temp fix since db still has old field name
-    @PropertyName("members")
     public void setUserScheduleResponseMap(Map<String, UserScheduleResponse> userScheduleResponseMap) {
         this.userScheduleResponseMap = userScheduleResponseMap;
     }

--- a/app/src/main/java/com/example/bigowlapp/model/Schedule.java
+++ b/app/src/main/java/com/example/bigowlapp/model/Schedule.java
@@ -3,7 +3,6 @@ package com.example.bigowlapp.model;
 import com.google.firebase.Timestamp;
 import com.google.firebase.firestore.GeoPoint;
 import com.google.firebase.firestore.IgnoreExtraProperties;
-import com.google.firebase.firestore.PropertyName;
 
 import java.util.Calendar;
 import java.util.List;

--- a/app/src/main/java/com/example/bigowlapp/model/ScheduleRequest.java
+++ b/app/src/main/java/com/example/bigowlapp/model/ScheduleRequest.java
@@ -6,9 +6,9 @@ import com.google.firebase.firestore.IgnoreExtraProperties;
 
 @IgnoreExtraProperties
 public class ScheduleRequest extends Notification {
-    private String senderUId;
-    private String receiverUId;
-    private String groupUId;
+    private String senderUid;
+    private String receiverUid;
+    private String groupUid;
     private Timestamp timeRead;
     private UserScheduleResponse senderResponse;
 
@@ -17,28 +17,28 @@ public class ScheduleRequest extends Notification {
         this.setType(Constants.SCHEDULE_TYPE);
     }
 
-    public String getSenderUId() {
-        return senderUId;
+    public String getSenderUid() {
+        return senderUid;
     }
 
-    public void setSenderUId(String senderUId) {
-        this.senderUId = senderUId;
+    public void setSenderUid(String senderUid) {
+        this.senderUid = senderUid;
     }
 
-    public String getReceiverUId() {
-        return receiverUId;
+    public String getReceiverUid() {
+        return receiverUid;
     }
 
-    public void setReceiverUId(String receiverUId) {
-        this.receiverUId = receiverUId;
+    public void setReceiverUid(String receiverUid) {
+        this.receiverUid = receiverUid;
     }
 
-    public String getGroupUId() {
-        return groupUId;
+    public String getGroupUid() {
+        return groupUid;
     }
 
-    public void setGroupUId(String groupUId) {
-        this.groupUId = groupUId;
+    public void setGroupUid(String groupUid) {
+        this.groupUid = groupUid;
     }
 
     public Timestamp getTimeRead() {

--- a/app/src/main/java/com/example/bigowlapp/model/ScheduleRequest.java
+++ b/app/src/main/java/com/example/bigowlapp/model/ScheduleRequest.java
@@ -10,8 +10,6 @@ public class ScheduleRequest extends Notification {
     private String receiverUId;
     private String groupUId;
     private Timestamp timeRead;
-    // TODO: remove timeSend,as it is redundant since 'time' is in base Notification class
-    private Timestamp timeSend;
     private UserScheduleResponse senderResponse;
 
     public ScheduleRequest() {
@@ -49,14 +47,6 @@ public class ScheduleRequest extends Notification {
 
     public void setTimeRead(Timestamp timeRead) {
         this.timeRead = timeRead;
-    }
-
-    public Timestamp getTimeSend() {
-        return timeSend;
-    }
-
-    public void setTimeSend(Timestamp timeSend) {
-        this.timeSend = timeSend;
     }
 
     public UserScheduleResponse getSenderResponse() {

--- a/app/src/main/java/com/example/bigowlapp/model/SupervisionRequest.java
+++ b/app/src/main/java/com/example/bigowlapp/model/SupervisionRequest.java
@@ -11,8 +11,6 @@ public class SupervisionRequest extends Notification implements Constants {
     private String receiverUId;
     private String groupUId;
     private Response response;
-    // TODO: remove timeSent,as it is redundant since 'time' is in base Notification class
-    private Timestamp timeSent;
     private Timestamp timeResponse;
 
     public SupervisionRequest() {
@@ -26,13 +24,12 @@ public class SupervisionRequest extends Notification implements Constants {
 
     public SupervisionRequest(String uId, Timestamp time, String senderUId,
                               String receiverUId, String groupUId, Response response,
-                              Timestamp timeSent, Timestamp timeResponse) {
+                              Timestamp timeResponse) {
         super(uId, SUPERVISION_TYPE, time);
         this.senderUId = senderUId;
         this.receiverUId = receiverUId;
         this.groupUId = groupUId;
         this.response = response;
-        this.timeSent = timeSent;
         this.timeResponse = timeResponse;
     }
 
@@ -66,14 +63,6 @@ public class SupervisionRequest extends Notification implements Constants {
 
     public void setResponse(Response response) {
         this.response = response;
-    }
-
-    public Timestamp getTimeSent() {
-        return timeSent;
-    }
-
-    public void setTimeSent(Timestamp timeSent) {
-        this.timeSent = timeSent;
     }
 
     public Timestamp getTimeResponse() {

--- a/app/src/main/java/com/example/bigowlapp/model/SupervisionRequest.java
+++ b/app/src/main/java/com/example/bigowlapp/model/SupervisionRequest.java
@@ -7,9 +7,9 @@ import com.google.firebase.firestore.IgnoreExtraProperties;
 @IgnoreExtraProperties
 public class SupervisionRequest extends Notification implements Constants {
 
-    private String senderUId;
-    private String receiverUId;
-    private String groupUId;
+    private String senderUid;
+    private String receiverUid;
+    private String groupUid;
     private Response response;
     private Timestamp timeResponse;
 
@@ -18,43 +18,43 @@ public class SupervisionRequest extends Notification implements Constants {
         this.setType(Constants.SUPERVISION_TYPE);
     }
 
-    public SupervisionRequest(String uId) {
-        super(uId, SUPERVISION_TYPE);
+    public SupervisionRequest(String uid) {
+        super(uid, SUPERVISION_TYPE);
     }
 
-    public SupervisionRequest(String uId, Timestamp time, String senderUId,
-                              String receiverUId, String groupUId, Response response,
+    public SupervisionRequest(String uid, Timestamp time, String senderUid,
+                              String receiverUid, String groupUid, Response response,
                               Timestamp timeResponse) {
-        super(uId, SUPERVISION_TYPE, time);
-        this.senderUId = senderUId;
-        this.receiverUId = receiverUId;
-        this.groupUId = groupUId;
+        super(uid, SUPERVISION_TYPE, time);
+        this.senderUid = senderUid;
+        this.receiverUid = receiverUid;
+        this.groupUid = groupUid;
         this.response = response;
         this.timeResponse = timeResponse;
     }
 
-    public String getSenderUId() {
-        return senderUId;
+    public String getSenderUid() {
+        return senderUid;
     }
 
-    public void setSenderUId(String senderUId) {
-        this.senderUId = senderUId;
+    public void setSenderUid(String senderUid) {
+        this.senderUid = senderUid;
     }
 
-    public String getReceiverUId() {
-        return receiverUId;
+    public String getReceiverUid() {
+        return receiverUid;
     }
 
-    public void setReceiverUId(String receiverUId) {
-        this.receiverUId = receiverUId;
+    public void setReceiverUid(String receiverUid) {
+        this.receiverUid = receiverUid;
     }
 
-    public String getGroupUId() {
-        return groupUId;
+    public String getGroupUid() {
+        return groupUid;
     }
 
-    public void setGroupUId(String groupUId) {
-        this.groupUId = groupUId;
+    public void setGroupUid(String groupUid) {
+        this.groupUid = groupUid;
     }
 
     public Response getResponse() {

--- a/app/src/main/java/com/example/bigowlapp/model/User.java
+++ b/app/src/main/java/com/example/bigowlapp/model/User.java
@@ -8,6 +8,8 @@ import androidx.annotation.NonNull;
 import com.google.firebase.firestore.Exclude;
 import com.google.firebase.firestore.IgnoreExtraProperties;
 
+import java.util.List;
+
 
 @IgnoreExtraProperties
 public class User extends Model implements Parcelable {
@@ -17,6 +19,7 @@ public class User extends Model implements Parcelable {
     private String phoneNumber;
     private String email;
     private String profileImage;
+    private List<String> memberGroupList;
 
     // TODO: Create a builder (possibly for all models)
 
@@ -31,13 +34,14 @@ public class User extends Model implements Parcelable {
         this.email = email;
     }
 
-    public User(String uid, String firstName, String lastName, String phoneNumber, String email, String profileImage) {
+    public User(String uid, String firstName, String lastName, String phoneNumber, String email, String profileImage, List<String> memberGroupList) {
         super(uid);
         this.firstName = firstName;
         this.lastName = lastName;
         this.phoneNumber = phoneNumber;
         this.email = email;
         this.profileImage = profileImage;
+        this.memberGroupList = memberGroupList;
     }
 
     protected User(Parcel in) {
@@ -47,6 +51,7 @@ public class User extends Model implements Parcelable {
         phoneNumber = in.readString();
         email = in.readString();
         profileImage = in.readString();
+        memberGroupList = in.createStringArrayList();
     }
 
     @Override
@@ -57,6 +62,7 @@ public class User extends Model implements Parcelable {
         dest.writeString(phoneNumber);
         dest.writeString(email);
         dest.writeString(profileImage);
+        dest.writeStringList(memberGroupList);
     }
 
     @Override
@@ -114,6 +120,14 @@ public class User extends Model implements Parcelable {
 
     public void setProfileImage(String profileImage) {
         this.profileImage = profileImage;
+    }
+
+    public List<String> getMemberGroupList() {
+        return memberGroupList;
+    }
+
+    public void setMemberGroupList(List<String> memberGroupList) {
+        this.memberGroupList = memberGroupList;
     }
 
     @Exclude

--- a/app/src/main/java/com/example/bigowlapp/model/User.java
+++ b/app/src/main/java/com/example/bigowlapp/model/User.java
@@ -19,7 +19,7 @@ public class User extends Model implements Parcelable {
     private String phoneNumber;
     private String email;
     private String profileImage;
-    private List<String> memberGroupList;
+    private List<String> memberGroupIdList;
 
     // TODO: Create a builder (possibly for all models)
 
@@ -34,14 +34,14 @@ public class User extends Model implements Parcelable {
         this.email = email;
     }
 
-    public User(String uid, String firstName, String lastName, String phoneNumber, String email, String profileImage, List<String> memberGroupList) {
+    public User(String uid, String firstName, String lastName, String phoneNumber, String email, String profileImage, List<String> memberGroupIdList) {
         super(uid);
         this.firstName = firstName;
         this.lastName = lastName;
         this.phoneNumber = phoneNumber;
         this.email = email;
         this.profileImage = profileImage;
-        this.memberGroupList = memberGroupList;
+        this.memberGroupIdList = memberGroupIdList;
     }
 
     protected User(Parcel in) {
@@ -51,7 +51,7 @@ public class User extends Model implements Parcelable {
         phoneNumber = in.readString();
         email = in.readString();
         profileImage = in.readString();
-        memberGroupList = in.createStringArrayList();
+        memberGroupIdList = in.createStringArrayList();
     }
 
     @Override
@@ -62,7 +62,7 @@ public class User extends Model implements Parcelable {
         dest.writeString(phoneNumber);
         dest.writeString(email);
         dest.writeString(profileImage);
-        dest.writeStringList(memberGroupList);
+        dest.writeStringList(memberGroupIdList);
     }
 
     @Override
@@ -122,12 +122,12 @@ public class User extends Model implements Parcelable {
         this.profileImage = profileImage;
     }
 
-    public List<String> getMemberGroupList() {
-        return memberGroupList;
+    public List<String> getMemberGroupIdList() {
+        return memberGroupIdList;
     }
 
-    public void setMemberGroupList(List<String> memberGroupList) {
-        this.memberGroupList = memberGroupList;
+    public void setMemberGroupIdList(List<String> memberGroupIdList) {
+        this.memberGroupIdList = memberGroupIdList;
     }
 
     @Exclude

--- a/app/src/main/java/com/example/bigowlapp/repository/ScheduleRepository.java
+++ b/app/src/main/java/com/example/bigowlapp/repository/ScheduleRepository.java
@@ -17,13 +17,13 @@ public class ScheduleRepository extends Repository<Schedule> {
         super("schedules");
     }
 
-    public Task<Void> updateScheduleMemberResponse(String scheduleId, String userUId, UserScheduleResponse currentUserScheduleResponse) {
-        return collectionReference.document(scheduleId).update("members.".concat(userUId), currentUserScheduleResponse);
+    public Task<Void> updateScheduleMemberResponse(String scheduleId, String userUid, UserScheduleResponse currentUserScheduleResponse) {
+        return collectionReference.document(scheduleId).update("members.".concat(userUid), currentUserScheduleResponse);
     }
 
     public LiveDataWithStatus<List<Schedule>> getListSchedulesFromGroupForUser(String groupID, String userID) {
         LiveDataWithStatus<List<Schedule>> listOfTData = new LiveDataWithStatus<>();
-        collectionReference.whereEqualTo("groupUId", groupID)
+        collectionReference.whereEqualTo("groupUid", groupID)
                 .whereArrayContains("memberList", userID)
                 .orderBy("startTime", Query.Direction.ASCENDING)
                 .get()

--- a/app/src/main/java/com/example/bigowlapp/viewModel/MonitoringGroupPageViewModel.java
+++ b/app/src/main/java/com/example/bigowlapp/viewModel/MonitoringGroupPageViewModel.java
@@ -37,7 +37,7 @@ public class MonitoringGroupPageViewModel extends BaseViewModel {
     private void loadGroup() {
         String userId = getCurrentUserUid();
         selectedGroup = repositoryFacade.getGroupRepository()
-                .getDocumentByAttribute("monitoringUserId", userId, Group.class);
+                .getDocumentByAttribute("supervisorId", userId, Group.class);
     }
 
     private void loadAllUsersInGroup(Group group) {

--- a/app/src/main/java/com/example/bigowlapp/viewModel/MonitoringGroupPageViewModel.java
+++ b/app/src/main/java/com/example/bigowlapp/viewModel/MonitoringGroupPageViewModel.java
@@ -42,7 +42,7 @@ public class MonitoringGroupPageViewModel extends BaseViewModel {
 
     private void loadAllUsersInGroup(Group group) {
         usersInGroup = repositoryFacade.getUserRepository()
-                .getDocumentsByListOfUid(group.getMemberIdList(), User.class);
+                .getListOfDocumentByArrayContains("memberGroupIdList", group.getUid(), User.class);
     }
 
     public void removeUserFromGroup(User userToBeRemoved) {

--- a/app/src/main/java/com/example/bigowlapp/viewModel/MonitoringGroupPageViewModel.java
+++ b/app/src/main/java/com/example/bigowlapp/viewModel/MonitoringGroupPageViewModel.java
@@ -42,12 +42,12 @@ public class MonitoringGroupPageViewModel extends BaseViewModel {
 
     private void loadAllUsersInGroup(Group group) {
         usersInGroup = repositoryFacade.getUserRepository()
-                .getDocumentsByListOfUid(group.getSupervisedUserId(), User.class);
+                .getDocumentsByListOfUid(group.getMemberIdList(), User.class);
     }
 
     public void removeUserFromGroup(User userToBeRemoved) {
         Group groupWithRemovedUser = getGroup().getValue();
-        Objects.requireNonNull(groupWithRemovedUser).getSupervisedUserId().remove(userToBeRemoved.getUid());
+        Objects.requireNonNull(groupWithRemovedUser).getMemberIdList().remove(userToBeRemoved.getUid());
 
         repositoryFacade.getGroupRepository()
                 .updateDocument(groupWithRemovedUser.getUid(), groupWithRemovedUser);

--- a/app/src/main/java/com/example/bigowlapp/viewModel/ScheduleViewRespondViewModel.java
+++ b/app/src/main/java/com/example/bigowlapp/viewModel/ScheduleViewRespondViewModel.java
@@ -61,7 +61,6 @@ public class ScheduleViewRespondViewModel extends BaseViewModel {
         newNotification.setGroupUId(scheduleData.getValue().getGroupUId());
         newNotification.setType("memberResponseSchedule");
         newNotification.setTimeRead(null);
-        newNotification.setTimeSend(now());
         newNotification.setTime(now());
         newNotification.setSenderResponse(currentUserNewResponse);
         repositoryFacade.getNotificationRepository().addDocument(newNotification);

--- a/app/src/main/java/com/example/bigowlapp/viewModel/ScheduleViewRespondViewModel.java
+++ b/app/src/main/java/com/example/bigowlapp/viewModel/ScheduleViewRespondViewModel.java
@@ -56,9 +56,9 @@ public class ScheduleViewRespondViewModel extends BaseViewModel {
 
     public void notifySupervisorScheduleResponse() {
         ScheduleRequest newNotification = new ScheduleRequest();
-        newNotification.setSenderUId(getCurrentUserUid());
-        newNotification.setReceiverUId(scheduleData.getValue().getGroupSupervisorUId());
-        newNotification.setGroupUId(scheduleData.getValue().getGroupUId());
+        newNotification.setSenderUid(getCurrentUserUid());
+        newNotification.setReceiverUid(scheduleData.getValue().getGroupSupervisorUid());
+        newNotification.setGroupUid(scheduleData.getValue().getGroupUid());
         newNotification.setType("memberResponseSchedule");
         newNotification.setTimeRead(null);
         newNotification.setTime(now());

--- a/app/src/main/java/com/example/bigowlapp/viewModel/SetScheduleViewModel.java
+++ b/app/src/main/java/com/example/bigowlapp/viewModel/SetScheduleViewModel.java
@@ -153,7 +153,7 @@ public class SetScheduleViewModel extends BaseViewModel {
             return new MutableLiveData<>(new ArrayList<>());
         }
         return repositoryFacade.getUserRepository()
-                .getDocumentsByListOfUid(group.getMemberIdList(), User.class);
+                .getListOfDocumentByArrayContains("memberGroupIdList", group.getUid(), User.class);
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/app/src/main/java/com/example/bigowlapp/viewModel/SetScheduleViewModel.java
+++ b/app/src/main/java/com/example/bigowlapp/viewModel/SetScheduleViewModel.java
@@ -55,8 +55,8 @@ public class SetScheduleViewModel extends BaseViewModel {
         Schedule schedule = newScheduleData.getValue();
         Map<String, UserScheduleResponse> userResponseMap =
                 schedule.getMemberList().stream().collect(Collectors.toMap(
-                        memberUId -> memberUId,
-                        memberUId -> new UserScheduleResponse(Response.NEUTRAL, null))
+                        memberUid -> memberUid,
+                        memberUid -> new UserScheduleResponse(Response.NEUTRAL, null))
                 );
         schedule.setUserScheduleResponseMap(userResponseMap);
         return repositoryFacade.getScheduleRepository().addDocument(schedule);
@@ -82,8 +82,8 @@ public class SetScheduleViewModel extends BaseViewModel {
 
     public void updateScheduleGroup(Group group) {
         this.selectedGroup = group;
-        this.newScheduleData.getValue().setGroupUId(group.getUid());
-        this.newScheduleData.getValue().setGroupSupervisorUId(group.getMonitoringUserId());
+        this.newScheduleData.getValue().setGroupUid(group.getUid());
+        this.newScheduleData.getValue().setGroupSupervisorUid(group.getMonitoringUserId());
 
         this.selectedUsers = new ArrayList<>();
         this.newScheduleData.getValue().setMemberList(new ArrayList<>());

--- a/app/src/main/java/com/example/bigowlapp/viewModel/SetScheduleViewModel.java
+++ b/app/src/main/java/com/example/bigowlapp/viewModel/SetScheduleViewModel.java
@@ -83,7 +83,7 @@ public class SetScheduleViewModel extends BaseViewModel {
     public void updateScheduleGroup(Group group) {
         this.selectedGroup = group;
         this.newScheduleData.getValue().setGroupUid(group.getUid());
-        this.newScheduleData.getValue().setGroupSupervisorUid(group.getMonitoringUserId());
+        this.newScheduleData.getValue().setGroupSupervisorUid(group.getSupervisorId());
 
         this.selectedUsers = new ArrayList<>();
         this.newScheduleData.getValue().setMemberList(new ArrayList<>());
@@ -149,11 +149,11 @@ public class SetScheduleViewModel extends BaseViewModel {
             return new MutableLiveData<>(listOfUserInGroupData.getValue());
         }
         previousSelectedGroup = group;
-        if (group == null || group.getSupervisedUserId().isEmpty()) {
+        if (group == null || group.getMemberIdList().isEmpty()) {
             return new MutableLiveData<>(new ArrayList<>());
         }
         return repositoryFacade.getUserRepository()
-                .getDocumentsByListOfUid(group.getSupervisedUserId(), User.class);
+                .getDocumentsByListOfUid(group.getMemberIdList(), User.class);
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/app/src/main/java/com/example/bigowlapp/viewModel/SetScheduleViewModel.java
+++ b/app/src/main/java/com/example/bigowlapp/viewModel/SetScheduleViewModel.java
@@ -73,7 +73,7 @@ public class SetScheduleViewModel extends BaseViewModel {
     private void loadListOfGroup() {
         String userId = getCurrentUserUid();
         listOfGroupData = repositoryFacade.getGroupRepository()
-                .getListOfDocumentByAttribute("monitoringUserId", userId, Group.class);
+                .getListOfDocumentByAttribute("supervisorId", userId, Group.class);
     }
 
     public void updateScheduleTitle(String title) {

--- a/app/src/main/java/com/example/bigowlapp/viewModel/SignUpViewModel.java
+++ b/app/src/main/java/com/example/bigowlapp/viewModel/SignUpViewModel.java
@@ -39,7 +39,7 @@ public class SignUpViewModel extends BaseViewModel {
         // add a default group when the user registers to a system where the user is the supervisor
         taskAddUser.addOnSuccessListener(isSuccess -> {
             Group group = new Group();
-            group.setMonitoringUserId(getCurrentUserUid());
+            group.setSupervisorId(getCurrentUserUid());
             group.setName(getFullName(firstName, lastName) + "'s group " + "#" + randomNumberStringGenerator());
             repositoryFacade.getGroupRepository().addDocument(group);
         });

--- a/app/src/main/java/com/example/bigowlapp/viewModel/SupervisedGroupListViewModel.java
+++ b/app/src/main/java/com/example/bigowlapp/viewModel/SupervisedGroupListViewModel.java
@@ -29,7 +29,7 @@ public class SupervisedGroupListViewModel extends BaseViewModel {
 
     private void loadListOfDocumentByArrayContains() {
         groupLiveData = repositoryFacade.getGroupRepository()
-                .getListOfDocumentByArrayContains("supervisedUserId",
+                .getListOfDocumentByArrayContains("memberIdList",
                         getCurrentUserUid(), Group.class);
     }
 

--- a/app/src/test/java/com/example/bigowlapp/viewModel/EditProfileViewModelTest.java
+++ b/app/src/test/java/com/example/bigowlapp/viewModel/EditProfileViewModelTest.java
@@ -51,7 +51,7 @@ public class EditProfileViewModelTest {
         when(repositoryFacade.getAuthRepository()).thenReturn(authRepository);
         when(repositoryFacade.getUserRepository()).thenReturn(userRepository);
 
-        testUser = new User("abc123", "first", "last", "+911", "test@mail.com", "url");
+        testUser = new User("abc123", "first", "last", "+911", "test@mail.com", "url", null);
         testUserData = new LiveDataWithStatus<>(testUser);
 
         when(authRepository.getCurrentUser()).thenReturn(testFirebaseUser);

--- a/app/src/test/java/com/example/bigowlapp/viewModel/ScheduleViewRespondViewModelTest.java
+++ b/app/src/test/java/com/example/bigowlapp/viewModel/ScheduleViewRespondViewModelTest.java
@@ -166,8 +166,8 @@ public class ScheduleViewRespondViewModelTest {
         userScheduleResponseMap.put(testUser.getUid(), new UserScheduleResponse(Response.NEUTRAL, null));
         Schedule fakeSchedule = Schedule.getPrototypeSchedule();
         fakeSchedule.setUid("test001");
-        fakeSchedule.setGroupUId("testGroup001");
-        fakeSchedule.setGroupSupervisorUId("fakeSupervisor001");
+        fakeSchedule.setGroupUid("testGroup001");
+        fakeSchedule.setGroupSupervisorUid("fakeSupervisor001");
         fakeSchedule.setUserScheduleResponseMap(userScheduleResponseMap);
         return fakeSchedule;
     }

--- a/app/src/test/java/com/example/bigowlapp/viewModel/ScheduleViewRespondViewModelTest.java
+++ b/app/src/test/java/com/example/bigowlapp/viewModel/ScheduleViewRespondViewModelTest.java
@@ -63,7 +63,7 @@ public class ScheduleViewRespondViewModelTest {
     @Before
     public void setUp() {
         // setup fake data
-        testUser = new User("abc123", "first", "last", "+911", "test@mail.com", "url");
+        testUser = new User("abc123", "first", "last", "+911", "test@mail.com", "url", null);
         testScheduleData = new LiveDataWithStatus<>(createFakeSchedule());
 
         // setup mock responses

--- a/app/src/test/java/com/example/bigowlapp/viewModel/SetScheduleViewModelTest.java
+++ b/app/src/test/java/com/example/bigowlapp/viewModel/SetScheduleViewModelTest.java
@@ -202,9 +202,9 @@ public class SetScheduleViewModelTest {
 
         // case where data was not loaded yet
         setScheduleViewModel.setPreviousSelectedGroup(null);
-        when(userRepository.getDocumentsByListOfUid(userIdsList, User.class)).thenReturn(new LiveDataWithStatus<>(userList));
+        when(userRepository.getListOfDocumentByArrayContains("memberGroupIdList", group.getUid(), User.class)).thenReturn(new LiveDataWithStatus<>(userList));
         scheduleUserList = setScheduleViewModel.getListOfUsersFromGroup(group).getValue();
-        verify(userRepository).getDocumentsByListOfUid(userIdsList, User.class);
+        verify(userRepository).getListOfDocumentByArrayContains("memberGroupIdList", group.getUid(), User.class);
         assertEquals(userList, scheduleUserList);
 
         // case where the group is empty

--- a/app/src/test/java/com/example/bigowlapp/viewModel/SetScheduleViewModelTest.java
+++ b/app/src/test/java/com/example/bigowlapp/viewModel/SetScheduleViewModelTest.java
@@ -127,8 +127,8 @@ public class SetScheduleViewModelTest {
 
         Schedule returnedSchedule = setScheduleViewModel.getNewScheduleData().getValue();
 
-        assertEquals(group.getUid(), returnedSchedule.getGroupUId());
-        assertEquals(group.getMonitoringUserId(), returnedSchedule.getGroupSupervisorUId());
+        assertEquals(group.getUid(), returnedSchedule.getGroupUid());
+        assertEquals(group.getMonitoringUserId(), returnedSchedule.getGroupSupervisorUid());
         assertEquals(new ArrayList<>(), returnedSchedule.getMemberList());
         assertEquals(group, setScheduleViewModel.getSelectedGroup());
         assertEquals(new ArrayList<>(), setScheduleViewModel.getSelectedUsers());

--- a/app/src/test/java/com/example/bigowlapp/viewModel/SetScheduleViewModelTest.java
+++ b/app/src/test/java/com/example/bigowlapp/viewModel/SetScheduleViewModelTest.java
@@ -104,10 +104,10 @@ public class SetScheduleViewModelTest {
     @Test
     public void getListOfGroup() {
         setScheduleViewModel.setListOfGroupData(null);
-        when(groupRepository.getListOfDocumentByAttribute("monitoringUserId", "123", Group.class)).thenReturn(new LiveDataWithStatus<>());
+        when(groupRepository.getListOfDocumentByAttribute("supervisorId", "123", Group.class)).thenReturn(new LiveDataWithStatus<>());
         assertNotNull(setScheduleViewModel.getListOfGroup());
         assertNotNull(setScheduleViewModel.getListOfGroup());
-        verify(groupRepository, times(1)).getListOfDocumentByAttribute("monitoringUserId", "123", Group.class);
+        verify(groupRepository, times(1)).getListOfDocumentByAttribute("supervisorId", "123", Group.class);
     }
 
     @Test

--- a/app/src/test/java/com/example/bigowlapp/viewModel/SetScheduleViewModelTest.java
+++ b/app/src/test/java/com/example/bigowlapp/viewModel/SetScheduleViewModelTest.java
@@ -121,14 +121,14 @@ public class SetScheduleViewModelTest {
     public void updateScheduleGroup() {
         Group group = new Group();
         group.setUid("GroupId");
-        group.setMonitoringUserId("MonitoringId");
+        group.setSupervisorId("MonitoringId");
 
         setScheduleViewModel.updateScheduleGroup(group);
 
         Schedule returnedSchedule = setScheduleViewModel.getNewScheduleData().getValue();
 
         assertEquals(group.getUid(), returnedSchedule.getGroupUid());
-        assertEquals(group.getMonitoringUserId(), returnedSchedule.getGroupSupervisorUid());
+        assertEquals(group.getSupervisorId(), returnedSchedule.getGroupSupervisorUid());
         assertEquals(new ArrayList<>(), returnedSchedule.getMemberList());
         assertEquals(group, setScheduleViewModel.getSelectedGroup());
         assertEquals(new ArrayList<>(), setScheduleViewModel.getSelectedUsers());
@@ -188,7 +188,7 @@ public class SetScheduleViewModelTest {
         }
 
         Group group = new Group();
-        group.setSupervisedUserId(userIdsList);
+        group.setMemberIdList(userIdsList);
 
         // case where same group already loaded is set
         setScheduleViewModel.setListOfUserInGroupData(new MutableLiveData<>(userList));
@@ -209,7 +209,7 @@ public class SetScheduleViewModelTest {
 
         // case where the group is empty
         setScheduleViewModel.setPreviousSelectedGroup(null);
-        group.setSupervisedUserId(new ArrayList<>());
+        group.setMemberIdList(new ArrayList<>());
         scheduleUserList = setScheduleViewModel.getListOfUsersFromGroup(group).getValue();
         assertEquals(new ArrayList<>(), scheduleUserList);
     }


### PR DESCRIPTION
<!--
NOTE: Please set, 
- reviewers for the PR
- assign yourself in "Assignees"
- "pull request" label for "Labels"
- set the correct "Milestone",
- set the "Linked Issues" to the issue this PR would close, if any

in the menu on the right
-->

### Related Issues
#138

### Description
Fixed the bug where monitoring group page couldn't load more than 10 users. 

Explanation for the bug: Specifically, we are using Firestore's _whereIn_'s function which only queries up to 10 entries. The optimal solution is to rework the database model, and use a much more optimal query.

The solution is for users to have a memberGroupIdList which contains the groups in which they are a member of. Then, we would use the ArrayContains function, which is a much more efficient and has no result limit, to query the data.

### How to check PR
There were many changes in the PR, but those are mostly refactors involving renaming things to be more precise. And, other files are fixes to those refactors, so do not worry too much about them; those refactor shouldn't change the behaviour of the code.

You only need to login to testUser1@email.com, and check if more than 10 users have loaded in the monitoringGroup page.

# PLEASE CHECK THESE FILES

**User.java
MonitoringGroupPageViewModel.java
SetScheduleViewModel.java**
